### PR TITLE
Update license in bower.json to match OSI shorthand.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "recognition"
   ],
   "main": "myscript-math-web.html",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "homepage": "https://myscript.github.io/myscript-math-web/components/myscript-math-web/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
While trying to fix your demo not working on beta.webcomponents.org, I had issues ingesting your element on our test server because of bad license data.

beta.webcomponents.org requires an OSI formatted license (https://opensource.org/licenses/alphabetical) to process elements. It can either get it from the github API or the bower.json. Github's API is in beta, so it may have flaked out somewhere and forgotten the license?

I fixed it for my testing with a fork and this change to bower.json. Accepting this change will ensure that myscript-math-web can continue to be ingested by beta.webcomponents.org.
